### PR TITLE
Fix revision input

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         isSnapshot = "true" == System.getProperty("build.snapshot", isSnapshotDefault)
 
         wazuh_version = System.getProperty("version", "5.0.0")
-        revision = System.getProperty("build.revision", "0")
+        revision = System.getProperty("build.revision", System.getProperty("revision", "0"))
 
         // 3.0.0-SNAPSHOT -> 3.0.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')

--- a/build.gradle
+++ b/build.gradle
@@ -9,13 +9,13 @@ buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "3.5.0-SNAPSHOT")
         artifactVersion = System.getProperty("version", "5.0.0")
-        artifactRevision = System.getProperty("build.revision", System.getProperty("revision", "0"))
+        artifactRevision = System.getProperty("revision", "0")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         isSnapshotDefault = "false"
         isSnapshot = "true" == System.getProperty("build.snapshot", isSnapshotDefault)
 
         wazuh_version = System.getProperty("version", "5.0.0")
-        revision = System.getProperty("build.revision", System.getProperty("revision", "0"))
+        revision = System.getProperty("revision", "0")
 
         // 3.0.0-SNAPSHOT -> 3.0.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')


### PR DESCRIPTION
### Description
This PR fixes the revision input so it is not set to `0` always resulting in the failure of the build process when the input is different from `0`

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1430

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).