### PR TITLE
Rename argument "build.revision" to "revision"

### DIFF
--- a/.github/workflows/5_builderpackage_alerting.yml
+++ b/.github/workflows/5_builderpackage_alerting.yml
@@ -114,7 +114,7 @@ jobs:
           key: m2-common-utils-${{ github.ref_name }}-${{ needs.branches.outputs.common_utils_ref }}-${{ needs.get-version.outputs.version }}-r${{ inputs.revision }}
 
       - name: Build and Test
-        run: ./gradlew build "-Dversion=${{ needs.get-version.outputs.version }}" "-Dbuild.revision=${{ inputs.revision }}" -x integTest
+        run: ./gradlew build "-Dversion=${{ needs.get-version.outputs.version }}" "-Drevision=${{ inputs.revision }}" -x integTest
         shell: bash
 
       - name: Prepare Artifacts

--- a/.github/workflows/5_testintegration_gradlecheck.yml
+++ b/.github/workflows/5_testintegration_gradlecheck.yml
@@ -84,5 +84,5 @@ jobs:
           key: m2-common-utils-${{ github.ref_name }}-${{ needs.branches.outputs.common_utils_ref }}-${{ needs.get-version.outputs.version }}-r0
 
       - name: Run Gradle check
-        run: ./gradlew check "-Dversion=${{ needs.get-version.outputs.version }}" "-Dbuild.revision=0"
+        run: ./gradlew check "-Dversion=${{ needs.get-version.outputs.version }}" "-Drevision=0"
         shell: bash


### PR DESCRIPTION
### Description
Renames build argument "build.revision" to "revision" for consistency accross repos.

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1439
