### PR TITLE
Rework caches in GH Workflows

### DIFF
--- a/.github/workflows/5_builderpackage_alerting.yml
+++ b/.github/workflows/5_builderpackage_alerting.yml
@@ -71,27 +71,17 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [branches, get-version]
     steps:
-      - name: Restore Maven Local Cache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.m2/repository
-          key: m2-common-utils-${{ github.ref_name }}-${{ needs.branches.outputs.common_utils_ref }}-${{ needs.get-version.outputs.version }}-r${{ inputs.revision }}
-          restore-keys: |
-            m2-common-utils-${{ github.ref_name }}-${{ needs.branches.outputs.common_utils_ref }}-
-            m2-common-utils-${{ github.ref_name }}-
-
       - name: Publish to Maven Local
         uses: wazuh/wazuh-indexer-common-utils/.github/actions/5_local_maven_publisher@main
         with:
           version: ${{ needs.get-version.outputs.version }}
           revision: ${{ inputs.revision }}
           reference: ${{ needs.branches.outputs.common_utils_ref }}
-
       - name: Cache Maven Local
         uses: actions/cache/save@v5
         with:
           path: ~/.m2/repository
-          key: m2-common-utils-${{ github.ref_name }}-${{ needs.branches.outputs.common_utils_ref }}-${{ needs.get-version.outputs.version }}-r${{ inputs.revision }}
+          key: ${{ github.run_id }}-common-utils
 
   build:
     env:
@@ -111,7 +101,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.m2/repository
-          key: m2-common-utils-${{ github.ref_name }}-${{ needs.branches.outputs.common_utils_ref }}-${{ needs.get-version.outputs.version }}-r${{ inputs.revision }}
+          key: ${{ github.run_id }}-common-utils
 
       - name: Build and Test
         run: ./gradlew build "-Dversion=${{ needs.get-version.outputs.version }}" "-Drevision=${{ inputs.revision }}" -x integTest

--- a/.github/workflows/5_testintegration_gradlecheck.yml
+++ b/.github/workflows/5_testintegration_gradlecheck.yml
@@ -4,7 +4,8 @@ name: (5.x) Run tests
 # - On any changes
 
 on:
-  push:
+  pull_request:
+    types: [synchronize]
     paths:
       - "**/src/**" # Match changes in source files.
       - "*.gradle" # Match changes in Gradle configuration.
@@ -45,27 +46,17 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [branches, get-version]
     steps:
-      - name: Restore Maven Local Cache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.m2/repository
-          key: m2-common-utils-${{ github.ref_name }}-${{ needs.branches.outputs.common_utils_ref }}-${{ needs.get-version.outputs.version }}-r0
-          restore-keys: |
-            m2-common-utils-${{ github.ref_name }}-${{ needs.branches.outputs.common_utils_ref }}-
-            m2-common-utils-${{ github.ref_name }}-
-
       - name: Publish common-utils to Maven Local
         uses: wazuh/wazuh-indexer-common-utils/.github/actions/5_local_maven_publisher@main
         with:
           version: ${{ needs.get-version.outputs.version }}
           revision: 0
           reference: ${{ needs.branches.outputs.common_utils_ref }}
-
       - name: Cache Maven Local
         uses: actions/cache/save@v5
         with:
           path: ~/.m2/repository
-          key: m2-common-utils-${{ github.ref_name }}-${{ needs.branches.outputs.common_utils_ref }}-${{ needs.get-version.outputs.version }}-r0
+          key: ${{ github.run_id }}-common-utils
 
   call-test-workflow:
     runs-on: ubuntu-24.04
@@ -76,13 +67,11 @@ jobs:
         with:
           distribution: temurin
           java-version: 25
-
-      - name: Restore Maven Local Cache
+      - name: Restore Maven Local cache (common-utils)
         uses: actions/cache/restore@v5
         with:
           path: ~/.m2/repository
-          key: m2-common-utils-${{ github.ref_name }}-${{ needs.branches.outputs.common_utils_ref }}-${{ needs.get-version.outputs.version }}-r0
-
+          key: ${{ github.run_id }}-common-utils
       - name: Run Gradle check
         run: ./gradlew check "-Dversion=${{ needs.get-version.outputs.version }}" "-Drevision=0"
         shell: bash


### PR DESCRIPTION
### Description
Uses .m2 cache to transport artifacts within the same workflow run.

**Validation**
- Run `./gradlew check`

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1443
