### PR TITLE
Reduce alerting plugin log verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
--
+- Reduce alerting plugin log verbosity [(#25)](https://github.com/wazuh/wazuh-indexer-alerting/pull/25)
 
 ### Deprecated
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -109,6 +109,7 @@ import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.index.query.BoolQueryBuilder
 import org.opensearch.index.query.Operator
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.index.query.QueryShardException
 import org.opensearch.index.seqno.SequenceNumbers
 import org.opensearch.indices.IndexClosedException
 import org.opensearch.monitor.jvm.JvmStats
@@ -878,12 +879,15 @@ class TransportDocLevelMonitorFanOutAction
                     updateLastRunContext(shard, currentSeqNo)
                 }
             } catch (e: Exception) {
-                log.error(
-                    "Monitor ${monitor.id} :" +
-                        "Failed to run fetch data from shard [$shard] of index [${indexExecutionCtx.concreteIndexName}]. " +
-                        "Error: ${e.message}",
-                    e
-                )
+                val msg = "Monitor ${monitor.id} :" +
+                    "Failed to run fetch data from shard [$shard] of index [${indexExecutionCtx.concreteIndexName}]. " +
+                    "Error: ${e.message}"
+                if (e is QueryShardException && e.message?.contains("No field mapping can be found") == true) {
+                    // Expected during WCS dynamic mapping bootstrap; resolves itself as data arrives.
+                    log.debug(msg, e)
+                } else {
+                    log.error(msg, e)
+                }
                 if (e is IndexClosedException) {
                     throw e
                 }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -879,14 +879,14 @@ class TransportDocLevelMonitorFanOutAction
                     updateLastRunContext(shard, currentSeqNo)
                 }
             } catch (e: Exception) {
-                val msg = "Monitor ${monitor.id} :" +
+                val message = "Monitor ${monitor.id} :" +
                     "Failed to run fetch data from shard [$shard] of index [${indexExecutionCtx.concreteIndexName}]. " +
                     "Error: ${e.message}"
                 if (e is QueryShardException && e.message?.contains("No field mapping can be found") == true) {
                     // Expected during WCS dynamic mapping bootstrap; resolves itself as data arrives.
-                    log.debug(msg, e)
+                    log.debug(message, e)
                 } else {
-                    log.error(msg, e)
+                    log.error(message, e)
                 }
                 if (e is IndexClosedException) {
                     throw e

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -514,10 +514,7 @@ class TransportIndexMonitorAction @Inject constructor(
                 .timeout(indexTimeout)
 
             log.info(
-                "Creating new monitor: ${request.monitor.toXContentWithUser(
-                    jsonBuilder(),
-                    ToXContent.MapParams(mapOf("with_type" to "true"))
-                )}"
+                "Creating new monitor: name=${request.monitor.name}, type=${request.monitor.monitorType}"
             )
 
             try {
@@ -687,10 +684,8 @@ class TransportIndexMonitorAction @Inject constructor(
                 .timeout(indexTimeout)
 
             log.info(
-                "Updating monitor, ${currentMonitor.id}, from: ${currentMonitor.toXContentWithUser(
-                    jsonBuilder(),
-                    ToXContent.MapParams(mapOf("with_type" to "true"))
-                )} \n to: ${request.monitor.toXContentWithUser(jsonBuilder(), ToXContent.MapParams(mapOf("with_type" to "true")))}"
+                "Updating monitor: id=${currentMonitor.id}, name=${request.monitor.name}, " +
+                    "type=${request.monitor.monitorType}"
             )
 
             try {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/DocLevelMonitorQueries.kt
@@ -460,7 +460,13 @@ class DocLevelMonitorQueries(private val client: Client, private val clusterServ
             }
             bulkResponse.forEach { bulkItemResponse ->
                 if (bulkItemResponse.isFailed) {
-                    log.error(bulkItemResponse.failureMessage)
+                    val failureMessage = bulkItemResponse.failureMessage
+                    if (failureMessage?.contains("No field mapping can be found") == true) {
+                        // Expected during WCS dynamic mapping bootstrap; resolves itself as data arrives.
+                        log.debug(failureMessage)
+                    } else {
+                        log.error(failureMessage)
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Description

Reduces two high-volume, low-value log entries throwed by the alerting plugin that were flooding the indexer log:

1. **`QueryShardException: No field mapping can be found for the field [X]`**, raised by DocumentLevel monitor queries when a field referenced by a detector rule hasn't been dynamically mapped yet on a WCS index.

2. **`Creating new monitor: ...` / `Updating monitor, ..., from: ... to: ...`**, both statements previously serialized the entire Monitor `XContent` JSON (two copies in the update case). For SAP-generated detectors the payload is large and makes the log practically unreadable. They now log only the monitor `id`, `name`, and `monitorType`.

Changes are strictly log-only, no behavior, control flow, or error-handling changes.


#### Validations

- Simplified new monitor logs
  ```bash
  # grep "new monitor:" /var/log/wazuh-indexer/wazuh-cluster.log 
  [2026-04-23T17:52:05,277][INFO ][o.o.a.t.TransportIndexMonitorAction] [node-1] Creating new monitor: name=wazuh-generic, type=doc_level_monitor
  [2026-04-23T17:52:05,479][INFO ][o.o.a.t.TransportIndexMonitorAction] [node-1] Creating new monitor: name=linux, type=doc_level_monitor
  [2026-04-23T17:52:05,482][INFO ][o.o.a.t.TransportIndexMonitorAction] [node-1] Creating new monitor: name=github, type=doc_level_monitor
  [2026-04-23T17:52:05,488][INFO ][o.o.a.t.TransportIndexMonitorAction] [node-1] Creating new monitor: name=azure, type=doc_level_monitor
  
  ```
- No `QueryShardException`
    ```bash
    # grep "QueryShardException" /var/log/wazuh-indexer/wazuh-cluster.log 
    root@vagrant:/home/vagrant# 
    ```

### Related Issues
Closes #7 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
