### PR TITLE
Add new AR monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Repo initialization [(#2)](https://github.com/wazuh/wazuh-indexer-alerting/pull/2)
 - Add Support Revert Bump Functionality [(#23)](https://github.com/wazuh/wazuh-indexer-alerting/pull/23)
+- Add new AR monitor [(#46)](https://github.com/wazuh/wazuh-indexer-alerting/pull/46)
 
 ### Dependencies
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -529,7 +529,12 @@ class DocumentLevelMonitorRunner : MonitorRunner() {
                             )
 
                             if (documentLevelTriggerRunResult.error != null) {
-                                triggerErrorMap[triggerId]!!.add(documentLevelTriggerRunResult.error as AlertingException)
+                                val error = if (documentLevelTriggerRunResult.error is AlertingException) {
+                                    documentLevelTriggerRunResult.error as AlertingException
+                                } else {
+                                    AlertingException.wrap(documentLevelTriggerRunResult.error!!) as AlertingException
+                                }
+                                triggerErrorMap[triggerId]!!.add(error)
                             }
                         }
                     }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorMetadataService.kt
@@ -166,12 +166,18 @@ object MonitorMetadataService :
     private suspend fun createUpdatedRunContext(
         monitor: Monitor
     ): Map<String, MutableMap<String, Any>> {
-        val monitorIndex = if (monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR.value)
+        val monitorIndex = if (
+            monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR.value ||
+            monitor.monitorType == Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR.value
+        )
             (monitor.inputs[0] as DocLevelMonitorInput).indices[0]
         else if (monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value))
             (monitor.inputs[0] as RemoteDocLevelMonitorInput).docLevelMonitorInput.indices[0]
         else null
-        val runContext = if (monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value))
+        val runContext = if (
+            monitor.monitorType == Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR.value ||
+            monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value)
+        )
             createFullRunContext(monitorIndex)
         else emptyMap()
         return runContext
@@ -204,12 +210,18 @@ object MonitorMetadataService :
 
     suspend fun recreateRunContext(metadata: MonitorMetadata, monitor: Monitor): MonitorMetadata {
         try {
-            val monitorIndex = if (monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR.value)
+            val monitorIndex = if (
+                monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR.value ||
+                monitor.monitorType == Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR.value
+            )
                 (monitor.inputs[0] as DocLevelMonitorInput).indices[0]
             else if (monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value))
                 (monitor.inputs[0] as RemoteDocLevelMonitorInput).docLevelMonitorInput.indices[0]
             else null
-            val runContext = if (monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value))
+            val runContext = if (
+                monitor.monitorType == Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR.value ||
+                monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value)
+            )
                 createFullRunContext(monitorIndex, metadata.lastRunContext as MutableMap<String, MutableMap<String, Any>>)
             else null
             return if (runContext != null) {
@@ -229,12 +241,18 @@ object MonitorMetadataService :
         createWithRunContext: Boolean,
         workflowMetadataId: String? = null,
     ): MonitorMetadata {
-        val monitorIndex = if (monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR.value)
+        val monitorIndex = if (
+            monitor.monitorType == Monitor.MonitorType.DOC_LEVEL_MONITOR.value ||
+            monitor.monitorType == Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR.value
+        )
             (monitor.inputs[0] as DocLevelMonitorInput).indices[0]
         else if (monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value))
             (monitor.inputs[0] as RemoteDocLevelMonitorInput).docLevelMonitorInput.indices[0]
         else null
-        val runContext = if (monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value))
+        val runContext = if (
+            monitor.monitorType == Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR.value ||
+            monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value)
+        )
             createFullRunContext(monitorIndex)
         else emptyMap()
         return MonitorMetadata(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/MonitorRunnerService.kt
@@ -52,6 +52,7 @@ import org.opensearch.alerting.settings.DestinationSettings.Companion.HOST_DENY_
 import org.opensearch.alerting.settings.DestinationSettings.Companion.loadDestinationSettings
 import org.opensearch.alerting.util.DocLevelMonitorQueries
 import org.opensearch.alerting.util.IndexUtils
+import org.opensearch.alerting.util.isActiveResponseMonitor
 import org.opensearch.alerting.util.isDocLevelMonitor
 import org.opensearch.alerting.workflow.CompositeWorkflowRunner
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver
@@ -482,7 +483,7 @@ object MonitorRunnerService : JobRunner, CoroutineScope, AbstractLifecycleCompon
                     executionId = executionId,
                     transportService = transportService
                 )
-            } else if (monitor.isDocLevelMonitor()) {
+            } else if (monitor.isDocLevelMonitor() || monitor.isActiveResponseMonitor()) {
                 DocumentLevelMonitorRunner().runMonitor(
                     monitor,
                     monitorCtx,

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -15,8 +15,10 @@ import org.opensearch.commons.alerting.action.AlertingActions
 import org.opensearch.commons.alerting.action.IndexMonitorRequest
 import org.opensearch.commons.alerting.action.IndexMonitorResponse
 import org.opensearch.commons.alerting.model.BucketLevelTrigger
+import org.opensearch.commons.alerting.model.CronSchedule
 import org.opensearch.commons.alerting.model.DocLevelMonitorInput
 import org.opensearch.commons.alerting.model.DocumentLevelTrigger
+import org.opensearch.commons.alerting.model.IntervalSchedule
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.QueryLevelTrigger
 import org.opensearch.commons.alerting.model.ScheduledJob
@@ -42,7 +44,9 @@ import org.opensearch.rest.RestResponse
 import org.opensearch.rest.action.RestResponseListener
 import org.opensearch.transport.client.node.NodeClient
 import java.io.IOException
+import java.time.Duration
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.*
 
 private val log = LogManager.getLogger(RestIndexMonitorAction::class.java)
@@ -135,6 +139,16 @@ class RestIndexMonitorAction : BaseRestHandler() {
                             }
                         }
                     }
+
+                    Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR -> {
+                        validateDocLevelQueryName(monitor)
+                        validateActiveResponseMonitor(monitor)
+                        triggers.forEach {
+                            if (it !is DocumentLevelTrigger) {
+                                throw IllegalArgumentException("Illegal trigger type, ${it.javaClass.name}, for active response monitor")
+                            }
+                        }
+                    }
                 }
             }
         } catch (e: Exception) {
@@ -163,6 +177,28 @@ class RestIndexMonitorAction : BaseRestHandler() {
                         "Doc level query name may not start with [_, +, -], contain '..', or contain: " +
                             getInvalidNameChars().replace("\\", "")
                     )
+                }
+            }
+        }
+    }
+
+    private fun validateActiveResponseMonitor(monitor: Monitor) {
+        // Validate schedule interval is less than 1 minute
+        val schedule = monitor.schedule
+        if (schedule is IntervalSchedule) {
+            val intervalMs = Duration.of(schedule.interval.toLong(), schedule.unit).toMillis()
+            require(intervalMs <= Duration.of(1, ChronoUnit.MINUTES).toMillis()) {
+                "Active response monitor schedule interval must be 1 minute or less."
+            }
+        } else if (schedule is CronSchedule) {
+            throw IllegalArgumentException("Active response monitor does not support cron schedules. Use an interval schedule of 1 minute or less.")
+        }
+
+        // Validate indices start with wazuh-findings-v5
+        monitor.inputs.filterIsInstance<DocLevelMonitorInput>().forEach { input ->
+            input.indices.forEach { index ->
+                require(index.startsWith("wazuh-findings-v5")) {
+                    "Active response monitor indices must start with 'wazuh-findings-v5'. Found: $index"
                 }
             }
         }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportExecuteMonitorAction.kt
@@ -136,9 +136,12 @@ class TransportExecuteMonitorAction @Inject constructor(
                     false -> (execMonitorRequest.monitor as Monitor).copy(user = user)
                 }
 
+                val execMonitorTypeEnum = if (monitor.isMonitorOfStandardType()) {
+                    Monitor.MonitorType.valueOf(monitor.monitorType.uppercase(Locale.ROOT))
+                } else null
                 if (
-                    monitor.isMonitorOfStandardType() &&
-                    Monitor.MonitorType.valueOf(monitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR
+                    execMonitorTypeEnum == Monitor.MonitorType.DOC_LEVEL_MONITOR ||
+                    execMonitorTypeEnum == Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR
                 ) {
                     try {
                         scope.launch {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -541,10 +541,12 @@ class TransportIndexMonitorAction @Inject constructor(
                     throw t
                 }
                 try {
+                    val monitorTypeEnum = if (request.monitor.isMonitorOfStandardType()) {
+                        Monitor.MonitorType.valueOf(request.monitor.monitorType.uppercase(Locale.ROOT))
+                    } else null
                     if (
-                        request.monitor.isMonitorOfStandardType() &&
-                        Monitor.MonitorType.valueOf(request.monitor.monitorType.uppercase(Locale.ROOT)) ==
-                        Monitor.MonitorType.DOC_LEVEL_MONITOR
+                        monitorTypeEnum == Monitor.MonitorType.DOC_LEVEL_MONITOR ||
+                        monitorTypeEnum == Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR
                     ) {
                         indexDocLevelMonitorQueries(request.monitor, indexResponse.id, metadata, request.refreshPolicy)
                     }
@@ -700,9 +702,10 @@ class TransportIndexMonitorAction @Inject constructor(
                 var isDocLevelMonitorRestarted = false
                 // Force re-creation of last run context if monitor is of type standard doc-level/threat-intel
                 // And monitor is re-enabled
-                if (request.monitor.enabled && !currentMonitor.enabled &&
-                    request.monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value)
-                ) {
+                val isDocOrActiveResponseType =
+                    request.monitor.monitorType.endsWith(Monitor.MonitorType.DOC_LEVEL_MONITOR.value) ||
+                        request.monitor.monitorType.endsWith(Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR.value)
+                if (request.monitor.enabled && !currentMonitor.enabled && isDocOrActiveResponseType) {
                     isDocLevelMonitorRestarted = true
                 }
 
@@ -715,10 +718,13 @@ class TransportIndexMonitorAction @Inject constructor(
                 // Recreate runContext if metadata exists
                 // Delete and insert all queries from/to queryIndex
 
-                if (!created &&
-                    currentMonitor.isMonitorOfStandardType() &&
-                    Monitor.MonitorType.valueOf(currentMonitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR
-                ) {
+                val currentMonitorTypeEnum = if (currentMonitor.isMonitorOfStandardType()) {
+                    Monitor.MonitorType.valueOf(currentMonitor.monitorType.uppercase(Locale.ROOT))
+                } else null
+                val isCurrentDocOrActiveResponse =
+                    currentMonitorTypeEnum == Monitor.MonitorType.DOC_LEVEL_MONITOR ||
+                        currentMonitorTypeEnum == Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR
+                if (!created && isCurrentDocOrActiveResponse) {
                     updatedMetadata = MonitorMetadataService.recreateRunContext(metadata, currentMonitor)
                     if (docLevelMonitorQueries.docLevelQueryIndexExists(currentMonitor.dataSources)) {
                         client.suspendUntil<Client, BulkByScrollResponse> {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexWorkflowAction.kt
@@ -419,7 +419,8 @@ class TransportIndexWorkflowAction @Inject constructor(
                     }
 
                     if (
-                        Monitor.MonitorType.valueOf(monitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR
+                        Monitor.MonitorType.valueOf(monitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR ||
+                        Monitor.MonitorType.valueOf(monitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR
                     ) {
                         val oldMonitorMetadata = MonitorMetadataService.getMetadata(monitor)
                         monitorMetadata = monitorMetadata.copy(sourceToQueryIndexMapping = oldMonitorMetadata!!.sourceToQueryIndexMapping)
@@ -581,9 +582,13 @@ class TransportIndexWorkflowAction @Inject constructor(
                         forceCreateLastRunContext = isWorkflowRestarted
                     )
 
-                    if (!created &&
-                        Monitor.MonitorType.valueOf(monitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR
-                    ) {
+                    val wfMonitorTypeEnum = if (monitor.isMonitorOfStandardType()) {
+                        Monitor.MonitorType.valueOf(monitor.monitorType.uppercase(Locale.ROOT))
+                    } else null
+                    val isWfDocOrActiveResponse =
+                        wfMonitorTypeEnum == Monitor.MonitorType.DOC_LEVEL_MONITOR ||
+                            wfMonitorTypeEnum == Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR
+                    if (!created && isWfDocOrActiveResponse) {
                         var updatedMetadata = MonitorMetadataService.recreateRunContext(monitorMetadata, monitor)
                         val oldMonitorMetadata = MonitorMetadataService.getMetadata(monitor)
                         updatedMetadata = updatedMetadata.copy(sourceToQueryIndexMapping = oldMonitorMetadata!!.sourceToQueryIndexMapping)
@@ -664,6 +669,7 @@ class TransportIndexWorkflowAction @Inject constructor(
         if (monitor.isMonitorOfStandardType()) {
             return when (Monitor.MonitorType.valueOf(monitor.monitorType.uppercase(Locale.ROOT))) {
                 Monitor.MonitorType.DOC_LEVEL_MONITOR -> (monitor.inputs[0] as DocLevelMonitorInput).indices
+                Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR -> (monitor.inputs[0] as DocLevelMonitorInput).indices
                 Monitor.MonitorType.BUCKET_LEVEL_MONITOR -> monitor.inputs.flatMap { s -> (s as SearchInput).indices }
                 Monitor.MonitorType.QUERY_LEVEL_MONITOR -> {
                     if (isADMonitor(monitor)) monitor.inputs.flatMap { s -> (s as SearchInput).indices }

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
@@ -88,6 +88,10 @@ fun Monitor.isQueryLevelMonitor(): Boolean =
     this.isMonitorOfStandardType() &&
         Monitor.MonitorType.valueOf(this.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.QUERY_LEVEL_MONITOR
 
+fun Monitor.isActiveResponseMonitor(): Boolean =
+    this.isMonitorOfStandardType() &&
+        Monitor.MonitorType.valueOf(this.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR
+
 /**
  * Since buckets can have multi-value keys, this converts the bucket key values to a string that can be used
  * as the key for a HashMap to easily retrieve [AggregationResultBucket] based on the bucket key values.
@@ -103,7 +107,7 @@ fun Action.getActionExecutionPolicy(monitor: Monitor): ActionExecutionPolicy? {
     // the parse.
     return this.actionExecutionPolicy ?: if (monitor.isBucketLevelMonitor()) {
         ActionExecutionPolicy.getDefaultConfigurationForBucketLevelMonitor()
-    } else if (monitor.isDocLevelMonitor()) {
+    } else if (monitor.isDocLevelMonitor() || monitor.isActiveResponseMonitor()) {
         ActionExecutionPolicy.getDefaultConfigurationForDocumentLevelMonitor()
     } else {
         null

--- a/alerting/src/main/kotlin/org/opensearch/alerting/workflow/CompositeWorkflowRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/workflow/CompositeWorkflowRunner.kt
@@ -15,6 +15,7 @@ import org.opensearch.alerting.QueryLevelMonitorRunner
 import org.opensearch.alerting.WorkflowMetadataService
 import org.opensearch.alerting.opensearchapi.suspendUntil
 import org.opensearch.alerting.script.ChainedAlertTriggerExecutionContext
+import org.opensearch.alerting.util.isActiveResponseMonitor
 import org.opensearch.alerting.util.isDocLevelMonitor
 import org.opensearch.alerting.util.isQueryLevelMonitor
 import org.opensearch.cluster.routing.Preference
@@ -265,7 +266,7 @@ object CompositeWorkflowRunner : WorkflowRunner() {
                 executionId,
                 transportService
             )
-        } else if (delegateMonitor.isDocLevelMonitor()) {
+        } else if (delegateMonitor.isDocLevelMonitor() || delegateMonitor.isActiveResponseMonitor()) {
             return DocumentLevelMonitorRunner().runMonitor(
                 delegateMonitor,
                 monitorCtx,


### PR DESCRIPTION
### Description
This PR adds the logic of the new AR monitor type, the main logic and where the checks are performed is located in: 
- alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt (`fun validateActiveResponseMonitor(monitor: Monitor)`)


### Related Issues
Resolves #8 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).