### PR TITLE
Fix findings batch drop on single error in publishFindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -
 
 ### Fixed
+- Fix publish-findings forEach try/catch dropping rest of batch on first error [(#49)](https://github.com/wazuh/wazuh-indexer-alerting/pull/49)
 
   
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -616,13 +616,15 @@ class TransportDocLevelMonitorFanOutAction
         }
 
         if (monitor.shouldCreateSingleAlertForFindings == null || monitor.shouldCreateSingleAlertForFindings == false) {
-            try {
-                findings.forEach { finding ->
+            findings.forEach { finding ->
+                // Per-iteration try/catch: a synchronous throw from publishFinding for one
+                // finding must not drop the remaining findings in this batch from the
+                // downstream subscriber (security-analytics enrichment + correlation).
+                try {
                     publishFinding(monitor, finding)
+                } catch (e: Exception) {
+                    log.error("Optional finding callback failed for finding ${finding.id}", e)
                 }
-            } catch (e: Exception) {
-                // suppress exception
-                log.error("Optional finding callback failed", e)
             }
         }
         this.findingsToTriggeredQueries += findingsToTriggeredQueries


### PR DESCRIPTION
### Description

A single failure while publishing a finding in `TransportDocLevelMonitorFanOutAction` could cause the rest of the batch to be silently dropped from the downstream subscriber (security-analytics enrichment + correlation), leaving findings without their enriched data.

The root cause was a `try/catch` wrapping the entire `findings.forEach { publishFinding(...) }` loop: if `publishFinding` threw synchronously for any one finding, the exception unwound the loop and skipped every subsequent finding in the batch.

### Changes

- Move the `try/catch` inside the `forEach` so each finding is published independently. A failure on one finding is logged (now including the offending `finding.id`) and the loop continues with the rest of the batch.
- Add a comment documenting why the per-iteration scope matters, to prevent this from being "simplified" back into a loop-wrapping `try/catch`.
- Update `CHANGELOG.md` under `Fixed`.

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-security-analytics/issues/168