### PR TITLE
Write active responses to wazuh-active-responses data stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fix publish-findings forEach try/catch dropping rest of batch on first error [(#49)](https://github.com/wazuh/wazuh-indexer-alerting/pull/49)
+- Write active responses to wazuh-active-responses data stream [(#63)](https://github.com/wazuh/wazuh-indexer-alerting/pull/63)
 
   
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/DocumentLevelMonitorRunner.kt
@@ -11,6 +11,7 @@ import org.opensearch.Version
 import org.opensearch.action.ActionListenerResponseHandler
 import org.opensearch.action.support.GroupedActionListener
 import org.opensearch.alerting.util.IndexUtils
+import org.opensearch.alerting.util.isActiveResponseMonitor
 import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.cluster.node.DiscoveryNode
 import org.opensearch.cluster.routing.ShardRouting
@@ -71,7 +72,9 @@ class DocumentLevelMonitorRunner : MonitorRunner() {
         try {
             monitorCtx.alertIndices!!.createOrUpdateAlertIndex(monitor.dataSources)
             monitorCtx.alertIndices!!.createOrUpdateInitialAlertHistoryIndex(monitor.dataSources)
-            monitorCtx.alertIndices!!.createOrUpdateInitialFindingHistoryIndex(monitor.dataSources)
+            if (!monitor.isActiveResponseMonitor()) {
+                monitorCtx.alertIndices!!.createOrUpdateInitialFindingHistoryIndex(monitor.dataSources)
+            }
         } catch (e: Exception) {
             val id = if (monitor.id.trim().isEmpty()) "_na_" else monitor.id
             val unwrappedException = ExceptionsHelper.unwrapCause(e)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/alerts/AlertIndices.kt
@@ -123,6 +123,9 @@ class AlertIndices(
         /** The alias of the index in which to write alert finding */
         const val FINDING_HISTORY_WRITE_INDEX = ".opensearch-alerting-finding-history-write"
 
+        /** External alias (owned by another Wazuh plugin) where Active Response monitor docs are written. */
+        const val WAZUH_ACTIVE_RESPONSES_WRITE_ALIAS = "wazuh-active-responses"
+
         /** The index name pattern referring to all alert history indices */
         const val ALERT_HISTORY_ALL = ".opendistro-alerting-alert-history*"
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/resthandler/RestIndexMonitorAction.kt
@@ -202,6 +202,12 @@ class RestIndexMonitorAction : BaseRestHandler() {
                 }
             }
         }
+
+        // Reject shouldCreateSingleAlertForFindings=true: that path skips per-doc findings creation,
+        // which is the only mechanism AR monitors use to emit docs into wazuh-active-responses-*.
+        require(monitor.shouldCreateSingleAlertForFindings != true) {
+            "Active response monitor does not support shouldCreateSingleAlertForFindings=true."
+        }
     }
 
     private fun validateDataSources(monitor: Monitor) { // Data Sources will currently be supported only at transport layer.

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -60,10 +60,12 @@ import org.opensearch.alerting.util.destinationmigration.publishLegacyNotificati
 import org.opensearch.alerting.util.destinationmigration.sendNotification
 import org.opensearch.alerting.util.getActionExecutionPolicy
 import org.opensearch.alerting.util.getCancelAfterTimeInterval
+import org.opensearch.alerting.util.isActiveResponseMonitor
 import org.opensearch.alerting.util.isAllowed
 import org.opensearch.alerting.util.isTestAction
 import org.opensearch.alerting.util.parseSampleDocTags
 import org.opensearch.alerting.util.printsSampleDocData
+import org.opensearch.alerting.util.targetFindingsIndex
 import org.opensearch.alerting.util.use
 import org.opensearch.cluster.routing.Preference
 import org.opensearch.cluster.service.ClusterService
@@ -397,6 +399,11 @@ class TransportDocLevelMonitorFanOutAction
         workflowRunContext: WorkflowRunContext?
     ): DocumentLevelTriggerRunResult {
         val triggerResult = triggerService.runDocLevelTrigger(monitor, trigger, queryToDocIds)
+        // Active response monitors must never go through the single-grouped-alert path — it skips findings entirely.
+        // Validation at create time rejects shouldCreateSingleAlertForFindings=true, but guard defensively.
+        if (monitor.isActiveResponseMonitor()) {
+            return DocumentLevelTriggerRunResult(trigger.name, listOf(), monitorResult.error)
+        }
         if (triggerResult.triggeredDocs.isNotEmpty()) {
             val findingIds = if (workflowRunContext?.findingIds != null) {
                 workflowRunContext.findingIds
@@ -461,6 +468,12 @@ class TransportDocLevelMonitorFanOutAction
             !dryrun && monitor.id != Monitor.NO_ID,
             executionId
         )
+
+        // Active response monitors persist their output to wazuh-active-responses-* via createFindings().
+        // They produce no alerts and no trigger actions; downstream consumers read the alias directly.
+        if (monitor.isActiveResponseMonitor()) {
+            return triggerResult
+        }
 
         findingToDocPairs.forEach {
             // Only pick those entries whose docs have triggers associated with them
@@ -604,7 +617,7 @@ class TransportDocLevelMonitorFanOutAction
                     monitor.shouldCreateSingleAlertForFindings == false
                 )
             ) {
-                indexRequests += IndexRequest(monitor.dataSources.findingsIndex)
+                indexRequests += IndexRequest(monitor.targetFindingsIndex())
                     .source(findingStr, XContentType.JSON)
                     .id(finding.id)
                     .opType(DocWriteRequest.OpType.CREATE)
@@ -615,7 +628,9 @@ class TransportDocLevelMonitorFanOutAction
             bulkIndexFindings(monitor, indexRequests)
         }
 
-        if (monitor.shouldCreateSingleAlertForFindings == null || monitor.shouldCreateSingleAlertForFindings == false) {
+        if (!monitor.isActiveResponseMonitor() &&
+            (monitor.shouldCreateSingleAlertForFindings == null || monitor.shouldCreateSingleAlertForFindings == false)
+        ) {
             findings.forEach { finding ->
                 // Per-iteration try/catch: a synchronous throw from publishFinding for one
                 // finding must not drop the remaining findings in this batch from the
@@ -650,7 +665,9 @@ class TransportDocLevelMonitorFanOutAction
                 log.debug("[${bulkResponse.items.size}] All findings successfully indexed.")
             }
         }
-        client.execute(RefreshAction.INSTANCE, RefreshRequest(monitor.dataSources.findingsIndex))
+        if (!monitor.isActiveResponseMonitor()) {
+            client.execute(RefreshAction.INSTANCE, RefreshRequest(monitor.targetFindingsIndex()))
+        }
     }
 
     private fun publishFinding(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -658,7 +658,10 @@ class TransportDocLevelMonitorFanOutAction
             if (bulkResponse.hasFailures()) {
                 bulkResponse.items.forEach { item ->
                     if (item.isFailed) {
-                        log.error("Failed indexing the finding ${item.id} of monitor [${monitor.id}]")
+                        log.error(
+                            "Failed indexing the finding ${item.id} of monitor [${monitor.id}] " +
+                                "into [${item.index}] (status=${item.status()}): ${item.failureMessage}"
+                        )
                     }
                 }
             } else {

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -460,13 +460,11 @@ class TransportDocLevelMonitorFanOutAction
 
         val triggerFindingDocPairs = mutableListOf<Pair<String, String>>()
 
-        // Active response monitors emit Wazuh-shaped docs (per active-responses.json template) for
-        // triggered source docs. They produce no findings, no alerts, and no trigger actions.
-        if (monitor.isActiveResponseMonitor()) {
-            if (!dryrun && monitor.id != Monitor.NO_ID) {
-                createActiveResponses(monitor, trigger, triggerResult.triggeredDocs)
-            }
-            return triggerResult
+        // Active response monitors emit a Wazuh-shaped doc to the wazuh-active-responses alias for each
+        // triggered source doc, then continue through the standard alert composition/save path so the
+        // firing surfaces via GET /_plugins/_alerting/monitors/alerts.
+        if (monitor.isActiveResponseMonitor() && !dryrun && monitor.id != Monitor.NO_ID) {
+            createActiveResponses(monitor, trigger, triggerResult.triggeredDocs)
         }
 
         // TODO: Implement throttling for findings
@@ -615,10 +613,13 @@ class TransportDocLevelMonitorFanOutAction
                     .string()
             log.trace("Findings: $findingStr")
 
+            // AR monitors persist only the Wazuh-shaped doc to wazuh-active-responses; suppress the
+            // standard finding write while still letting Finding objects exist in memory so alert
+            // composition above has finding IDs to attach.
             if (shouldCreateFinding and (
                 monitor.shouldCreateSingleAlertForFindings == null ||
                     monitor.shouldCreateSingleAlertForFindings == false
-                )
+                ) && !monitor.isActiveResponseMonitor()
             ) {
                 indexRequests += IndexRequest(monitor.dataSources.findingsIndex)
                     .source(findingStr, XContentType.JSON)

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -100,6 +100,7 @@ import org.opensearch.commons.alerting.model.action.PerAlertActionScope
 import org.opensearch.commons.alerting.model.userErrorMessage
 import org.opensearch.commons.alerting.util.AlertingException
 import org.opensearch.commons.alerting.util.string
+import org.opensearch.commons.notifications.model.ActiveResponse
 import org.opensearch.commons.notifications.model.NotificationConfigInfo
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.common.Strings
@@ -663,6 +664,7 @@ class TransportDocLevelMonitorFanOutAction
     ) {
         if (triggeredDocs.isEmpty()) return
 
+        val activeResponseConfig = fetchActiveResponseConfig(monitor, trigger)
         val sourceWazuhByKey = fetchSourceWazuhSubtrees(monitor, triggeredDocs)
         val timestamp = Instant.now().toString()
         val indexRequests = mutableListOf<IndexRequest>()
@@ -676,7 +678,7 @@ class TransportDocLevelMonitorFanOutAction
             val doc: Map<String, Any> = mapOf(
                 "@timestamp" to timestamp,
                 "event" to mapOf("doc_id" to docId, "index" to sourceIndex),
-                "wazuh" to buildWazuhSubtree(trigger, sourceWazuhByKey[key])
+                "wazuh" to buildWazuhSubtree(trigger, activeResponseConfig, sourceWazuhByKey[key])
             )
 
             val builder = XContentFactory.jsonBuilder().map(doc)
@@ -690,7 +692,55 @@ class TransportDocLevelMonitorFanOutAction
         }
     }
 
-    private fun buildWazuhSubtree(trigger: DocumentLevelTrigger, sourceWazuh: Map<String, Any>?): Map<String, Any> {
+    /**
+     * Fetches the [ActiveResponse] channel configuration from the notification channel
+     * referenced by the trigger's first action. Reads directly from the notifications
+     * system index to avoid permission issues with the notifications plugin API.
+     * Returns null if no action is configured, the config is not found, or it is not
+     * an active_response type.
+     */
+    private suspend fun fetchActiveResponseConfig(monitor: Monitor, trigger: DocumentLevelTrigger): ActiveResponse? {
+        val destinationId = trigger.actions.firstOrNull()?.destinationId
+        if (destinationId.isNullOrEmpty()) {
+            log.warn("AR trigger [${trigger.name}] has no actions with a destination; active_response fields will be incomplete")
+            return null
+        }
+        return try {
+            val getRequest = org.opensearch.action.get.GetRequest(".opensearch-notifications-config", destinationId)
+            val response: org.opensearch.action.get.GetResponse = client.threadPool().threadContext.stashContext().use {
+                client.suspendUntil { client.get(getRequest, it) }
+            }
+            if (!response.isExists) {
+                log.warn("Notification config [$destinationId] not found in notifications index")
+                return null
+            }
+            val source = response.sourceAsMap
+            val config = source["config"] as? Map<String, Any> ?: return null
+            val configType = config["config_type"] as? String
+            if (configType != "active_response") {
+                log.warn("Notification config [$destinationId] is type [$configType], not active_response")
+                return null
+            }
+            val arMap = config["active_response"] as? Map<String, Any> ?: return null
+            ActiveResponse(
+                type = arMap["type"] as? String ?: return null,
+                statefulTimeout = (arMap["stateful_timeout"] as? Number)?.toInt(),
+                executable = arMap["executable"] as? String ?: return null,
+                args = arMap["extra_args"] as? String,
+                location = arMap["location"] as? String ?: return null,
+                agentId = arMap["agent_id"] as? String
+            )
+        } catch (e: Exception) {
+            log.warn("Failed to fetch AR channel config for destination [$destinationId]: ${e.message}")
+            null
+        }
+    }
+
+    private fun buildWazuhSubtree(
+        trigger: DocumentLevelTrigger,
+        arConfig: ActiveResponse?,
+        sourceWazuh: Map<String, Any>?
+    ): Map<String, Any> {
         // Top-level keys under "wazuh" that the active-responses template declares. Anything else
         // present on the source finding (e.g. "rule") is stripped to avoid strict-mapping rejection.
         val allowed = setOf("agent", "cluster", "event", "integration", "protocol", "schema", "space", "threat")
@@ -698,7 +748,17 @@ class TransportDocLevelMonitorFanOutAction
         sourceWazuh?.forEach { (k, v) ->
             if (k in allowed && v != null) out[k] = v
         }
-        out["active_response"] = mapOf("name" to trigger.name)
+
+        val arFields = mutableMapOf<String, Any>("name" to trigger.name)
+        if (arConfig != null) {
+            arFields["executable"] = arConfig.executable
+            arFields["location"] = arConfig.location
+            arFields["type"] = arConfig.type
+            arConfig.agentId?.let { arFields["agent_id"] = it }
+            arConfig.statefulTimeout?.let { arFields["stateful_timeout"] = it }
+            arConfig.args?.let { arFields["extra_arguments"] = it }
+        }
+        out["active_response"] = arFields
         return out
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -31,6 +31,7 @@ import org.opensearch.alerting.TriggerService
 import org.opensearch.alerting.action.GetDestinationsAction
 import org.opensearch.alerting.action.GetDestinationsRequest
 import org.opensearch.alerting.action.GetDestinationsResponse
+import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.model.AlertContext
 import org.opensearch.alerting.model.destination.Destination
 import org.opensearch.alerting.model.destination.DestinationContextFactory
@@ -65,7 +66,6 @@ import org.opensearch.alerting.util.isAllowed
 import org.opensearch.alerting.util.isTestAction
 import org.opensearch.alerting.util.parseSampleDocTags
 import org.opensearch.alerting.util.printsSampleDocData
-import org.opensearch.alerting.util.targetFindingsIndex
 import org.opensearch.alerting.util.use
 import org.opensearch.cluster.routing.Preference
 import org.opensearch.cluster.service.ClusterService
@@ -460,6 +460,15 @@ class TransportDocLevelMonitorFanOutAction
 
         val triggerFindingDocPairs = mutableListOf<Pair<String, String>>()
 
+        // Active response monitors emit Wazuh-shaped docs (per active-responses.json template) for
+        // triggered source docs. They produce no findings, no alerts, and no trigger actions.
+        if (monitor.isActiveResponseMonitor()) {
+            if (!dryrun && monitor.id != Monitor.NO_ID) {
+                createActiveResponses(monitor, trigger, triggerResult.triggeredDocs)
+            }
+            return triggerResult
+        }
+
         // TODO: Implement throttling for findings
         val findingToDocPairs = createFindings(
             monitor,
@@ -468,12 +477,6 @@ class TransportDocLevelMonitorFanOutAction
             !dryrun && monitor.id != Monitor.NO_ID,
             executionId
         )
-
-        // Active response monitors persist their output to wazuh-active-responses-* via createFindings().
-        // They produce no alerts and no trigger actions; downstream consumers read the alias directly.
-        if (monitor.isActiveResponseMonitor()) {
-            return triggerResult
-        }
 
         findingToDocPairs.forEach {
             // Only pick those entries whose docs have triggers associated with them
@@ -617,7 +620,7 @@ class TransportDocLevelMonitorFanOutAction
                     monitor.shouldCreateSingleAlertForFindings == false
                 )
             ) {
-                indexRequests += IndexRequest(monitor.targetFindingsIndex())
+                indexRequests += IndexRequest(monitor.dataSources.findingsIndex)
                     .source(findingStr, XContentType.JSON)
                     .id(finding.id)
                     .opType(DocWriteRequest.OpType.CREATE)
@@ -647,6 +650,95 @@ class TransportDocLevelMonitorFanOutAction
         return findingDocPairs
     }
 
+    /**
+     * Emits one Wazuh-shaped document per triggered source doc into the wazuh-active-responses
+     * data stream. Schema is dictated by the active-responses.json template owned by the
+     * Wazuh setup plugin (strict mapping): @timestamp + event.{doc_id,index} + wazuh.* subtree.
+     */
+    private suspend fun createActiveResponses(
+        monitor: Monitor,
+        trigger: DocumentLevelTrigger,
+        triggeredDocs: Collection<String>,
+    ) {
+        if (triggeredDocs.isEmpty()) return
+
+        val sourceWazuhByKey = fetchSourceWazuhSubtrees(monitor, triggeredDocs)
+        val timestamp = Instant.now().toString()
+        val indexRequests = mutableListOf<IndexRequest>()
+
+        triggeredDocs.forEach { key ->
+            val parts = key.split("|")
+            if (parts.size != 2 || parts[0].isEmpty() || parts[1].isEmpty()) return@forEach
+            val docId = parts[0]
+            val sourceIndex = parts[1]
+
+            val doc: Map<String, Any> = mapOf(
+                "@timestamp" to timestamp,
+                "event" to mapOf("doc_id" to docId, "index" to sourceIndex),
+                "wazuh" to buildWazuhSubtree(trigger, sourceWazuhByKey[key])
+            )
+
+            val builder = XContentFactory.jsonBuilder().map(doc)
+            indexRequests += IndexRequest(AlertIndices.WAZUH_ACTIVE_RESPONSES_WRITE_ALIAS)
+                .source(BytesReference.bytes(builder), XContentType.JSON)
+                .opType(DocWriteRequest.OpType.CREATE)
+        }
+
+        if (indexRequests.isNotEmpty()) {
+            bulkIndexFindings(monitor, indexRequests)
+        }
+    }
+
+    private fun buildWazuhSubtree(trigger: DocumentLevelTrigger, sourceWazuh: Map<String, Any>?): Map<String, Any> {
+        // Top-level keys under "wazuh" that the active-responses template declares. Anything else
+        // present on the source finding (e.g. "rule") is stripped to avoid strict-mapping rejection.
+        val allowed = setOf("agent", "cluster", "event", "integration", "protocol", "schema", "space", "threat")
+        val out = mutableMapOf<String, Any>()
+        sourceWazuh?.forEach { (k, v) ->
+            if (k in allowed && v != null) out[k] = v
+        }
+        out["active_response"] = mapOf("name" to trigger.name)
+        return out
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun fetchSourceWazuhSubtrees(
+        monitor: Monitor,
+        triggeredDocs: Collection<String>,
+    ): Map<String, Map<String, Any>> {
+        val result = mutableMapOf<String, Map<String, Any>>()
+        triggeredDocs.chunked(findingsIndexBatchSize).forEach { batch ->
+            val request = MultiGetRequest()
+            val keyByDocIdIndex = mutableMapOf<Pair<String, String>, String>()
+            batch.forEach { key ->
+                val parts = key.split("|")
+                if (parts.size != 2 || parts[0].isEmpty() || parts[1].isEmpty()) return@forEach
+                val docId = parts[0]
+                val sourceIndex = parts[1]
+                keyByDocIdIndex[docId to sourceIndex] = key
+                request.add(
+                    MultiGetRequest.Item(sourceIndex, docId)
+                        .fetchSourceContext(FetchSourceContext(true, arrayOf("wazuh"), emptyArray()))
+                )
+            }
+            if (request.items.isEmpty()) return@forEach
+            val response = client.suspendUntil { client.multiGet(request, it) }
+            response.responses.forEach { item ->
+                if (item.isFailed) {
+                    log.warn(
+                        "AR source doc mget failed for monitor [${monitor.id}] doc ${item.id}: ${item.failure?.message}"
+                    )
+                    return@forEach
+                }
+                val src = item.response?.sourceAsMap ?: return@forEach
+                val wazuh = src["wazuh"] as? Map<String, Any> ?: return@forEach
+                val key = keyByDocIdIndex[item.id to item.index] ?: return@forEach
+                result[key] = wazuh
+            }
+        }
+        return result
+    }
+
     private suspend fun bulkIndexFindings(
         monitor: Monitor,
         indexRequests: List<IndexRequest>
@@ -669,7 +761,7 @@ class TransportDocLevelMonitorFanOutAction
             }
         }
         if (!monitor.isActiveResponseMonitor()) {
-            client.execute(RefreshAction.INSTANCE, RefreshRequest(monitor.targetFindingsIndex()))
+            client.execute(RefreshAction.INSTANCE, RefreshRequest(monitor.dataSources.findingsIndex))
         }
     }
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
@@ -8,7 +8,6 @@ package org.opensearch.alerting.util
 import org.apache.logging.log4j.LogManager
 import org.opensearch.alerting.AlertService
 import org.opensearch.alerting.MonitorRunnerService
-import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.model.AlertContext
 import org.opensearch.alerting.model.destination.Destination
 import org.opensearch.alerting.script.BucketLevelTriggerExecutionContext
@@ -92,10 +91,6 @@ fun Monitor.isQueryLevelMonitor(): Boolean =
 fun Monitor.isActiveResponseMonitor(): Boolean =
     this.isMonitorOfStandardType() &&
         Monitor.MonitorType.valueOf(this.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR
-
-fun Monitor.targetFindingsIndex(): String =
-    if (this.isActiveResponseMonitor()) AlertIndices.WAZUH_ACTIVE_RESPONSES_WRITE_ALIAS
-    else this.dataSources.findingsIndex
 
 /**
  * Since buckets can have multi-value keys, this converts the bucket key values to a string that can be used

--- a/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/util/AlertingUtils.kt
@@ -8,6 +8,7 @@ package org.opensearch.alerting.util
 import org.apache.logging.log4j.LogManager
 import org.opensearch.alerting.AlertService
 import org.opensearch.alerting.MonitorRunnerService
+import org.opensearch.alerting.alerts.AlertIndices
 import org.opensearch.alerting.model.AlertContext
 import org.opensearch.alerting.model.destination.Destination
 import org.opensearch.alerting.script.BucketLevelTriggerExecutionContext
@@ -91,6 +92,10 @@ fun Monitor.isQueryLevelMonitor(): Boolean =
 fun Monitor.isActiveResponseMonitor(): Boolean =
     this.isMonitorOfStandardType() &&
         Monitor.MonitorType.valueOf(this.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR
+
+fun Monitor.targetFindingsIndex(): String =
+    if (this.isActiveResponseMonitor()) AlertIndices.WAZUH_ACTIVE_RESPONSES_WRITE_ALIAS
+    else this.dataSources.findingsIndex
 
 /**
  * Since buckets can have multi-value keys, this converts the bucket key values to a string that can be used

--- a/alerting/src/test/kotlin/org/opensearch/alerting/ActiveResponseMonitorOutputIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/ActiveResponseMonitorOutputIT.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.alerting
+
+import org.apache.hc.core5.http.ContentType
+import org.apache.hc.core5.http.io.entity.StringEntity
+import org.opensearch.action.search.SearchResponse
+import org.opensearch.alerting.alerts.AlertIndices
+import org.opensearch.client.ResponseException
+import org.opensearch.common.xcontent.json.JsonXContent
+import org.opensearch.commons.alerting.model.DocLevelMonitorInput
+import org.opensearch.commons.alerting.model.DocLevelQuery
+import org.opensearch.commons.alerting.model.IntervalSchedule
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.core.rest.RestStatus
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class ActiveResponseMonitorOutputIT : AlertingRestTestCase() {
+
+    private val arWriteAlias = AlertIndices.WAZUH_ACTIVE_RESPONSES_WRITE_ALIAS
+
+    fun `test active response monitor writes to wazuh-active-responses and skips findings and alerts`() {
+        val sourceIndex = "wazuh-findings-v5-test-${randomAlphaOfLength(6).lowercase()}"
+        createTestIndex(
+            sourceIndex,
+            """
+            "properties" : {
+              "rule" : {
+                "properties" : {
+                  "level" : { "type" : "integer" }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        // Pre-create the AR destination index. In production this alias is owned by another
+        // Wazuh plugin; here we seed it explicitly so the write isn't relying on auto-create.
+        adminClient().makeRequest("PUT", "/$arWriteAlias")
+
+        val testDoc = """{ "rule" : { "level" : 10 } }"""
+        indexDoc(sourceIndex, "1", testDoc)
+
+        val docQuery = DocLevelQuery(query = "rule.level:>=10", name = "high_severity", fields = listOf())
+        val docLevelInput = DocLevelMonitorInput("description", listOf(sourceIndex), listOf(docQuery))
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        val arMonitor = Monitor(
+            name = "ar-output-it-${randomAlphaOfLength(5)}",
+            monitorType = Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR.value,
+            enabled = true,
+            inputs = listOf(docLevelInput),
+            schedule = IntervalSchedule(interval = 1, unit = ChronoUnit.MINUTES),
+            triggers = listOf(trigger),
+            enabledTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            lastUpdateTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            user = randomUser(),
+            uiMetadata = mapOf()
+        )
+
+        val monitor = createMonitor(arMonitor)
+        assertNotNull(monitor.id)
+
+        executeMonitor(monitor.id)
+
+        // AR path skips the synchronous refresh in bulkIndexFindings, so refresh explicitly before asserting.
+        refreshIndex(arWriteAlias)
+        val arHits = searchHitsByMonitorId(arWriteAlias, monitor.id)
+        assertEquals("AR doc was not written to $arWriteAlias", 1, arHits)
+
+        // Findings history index must be empty for this monitor.
+        val findingsHits = searchHitsByMonitorId(AlertIndices.ALL_FINDING_INDEX_PATTERN, monitor.id)
+        assertEquals("AR monitor must not write to the findings history index", 0, findingsHits)
+
+        // Alert index must contain no doc-level alerts for this monitor.
+        val alertHits = searchHitsByMonitorId(AlertIndices.ALERT_INDEX, monitor.id)
+        assertEquals("AR monitor must not produce alerts", 0, alertHits)
+    }
+
+    fun `test active response monitor rejects shouldCreateSingleAlertForFindings`() {
+        val sourceIndex = "wazuh-findings-v5-test-${randomAlphaOfLength(6).lowercase()}"
+        createTestIndex(sourceIndex)
+
+        val docQuery = DocLevelQuery(query = "test_field:\"x\"", name = "q", fields = listOf())
+        val docLevelInput = DocLevelMonitorInput("description", listOf(sourceIndex), listOf(docQuery))
+        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+
+        val invalidMonitor = Monitor(
+            name = "ar-bad-${randomAlphaOfLength(5)}",
+            monitorType = Monitor.MonitorType.ACTIVE_RESPONSE_MONITOR.value,
+            enabled = true,
+            inputs = listOf(docLevelInput),
+            schedule = IntervalSchedule(interval = 1, unit = ChronoUnit.MINUTES),
+            triggers = listOf(trigger),
+            enabledTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            lastUpdateTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            user = randomUser(),
+            uiMetadata = mapOf(),
+            shouldCreateSingleAlertForFindings = true
+        )
+
+        try {
+            createMonitor(invalidMonitor)
+            fail("Expected validation failure for shouldCreateSingleAlertForFindings=true on AR monitor")
+        } catch (e: ResponseException) {
+            assertEquals(RestStatus.BAD_REQUEST, e.response.restStatus())
+            assertTrue(
+                "Unexpected error: ${e.message}",
+                e.message!!.contains("shouldCreateSingleAlertForFindings", ignoreCase = true)
+            )
+        }
+    }
+
+    private fun searchHitsByMonitorId(index: String, monitorId: String): Int {
+        val body = """
+            { "query" : { "term" : { "monitor_id" : "$monitorId" } } }
+        """.trimIndent()
+        val response = adminClient().makeRequest(
+            "GET", "/$index/_search?ignore_unavailable=true",
+            StringEntity(body, ContentType.APPLICATION_JSON)
+        )
+        assertEquals("Search failed on $index", RestStatus.OK, response.restStatus())
+        val parser = createParser(JsonXContent.jsonXContent, response.entity.content)
+        val searchResponse = SearchResponse.fromXContent(parser)
+        return searchResponse.hits.hits.size
+    }
+}

--- a/alerting/src/test/kotlin/org/opensearch/alerting/ActiveResponseMonitorOutputIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/ActiveResponseMonitorOutputIT.kt
@@ -23,31 +23,51 @@ class ActiveResponseMonitorOutputIT : AlertingRestTestCase() {
 
     private val arWriteAlias = AlertIndices.WAZUH_ACTIVE_RESPONSES_WRITE_ALIAS
 
-    fun `test active response monitor writes to wazuh-active-responses and skips findings and alerts`() {
+    fun `test active response monitor emits wazuh-shaped doc to wazuh-active-responses`() {
         val sourceIndex = "wazuh-findings-v5-test-${randomAlphaOfLength(6).lowercase()}"
+        // Source-doc mapping covers the fields the AR write reads (wazuh.agent.*) and the doc-level query (rule.level).
         createTestIndex(
             sourceIndex,
             """
             "properties" : {
-              "rule" : {
+              "rule" : { "properties" : { "level" : { "type" : "integer" } } },
+              "wazuh" : {
                 "properties" : {
-                  "level" : { "type" : "integer" }
+                  "agent" : {
+                    "properties" : {
+                      "id" : { "type" : "keyword" },
+                      "name" : { "type" : "keyword" }
+                    }
+                  },
+                  "cluster" : {
+                    "properties" : { "name" : { "type" : "keyword" } }
+                  }
                 }
               }
             }
             """.trimIndent()
         )
 
-        // Pre-create the AR destination index. In production this alias is owned by another
-        // Wazuh plugin; here we seed it explicitly so the write isn't relying on auto-create.
+        // Pre-create the destination index. In production, this alias maps to a data stream owned by
+        // another Wazuh plugin; the test substitutes a plain index because the data stream template
+        // is not installed in the alerting integTest cluster.
         adminClient().makeRequest("PUT", "/$arWriteAlias")
 
-        val testDoc = """{ "rule" : { "level" : 10 } }"""
-        indexDoc(sourceIndex, "1", testDoc)
+        val testDoc = """
+            {
+              "rule" : { "level" : 10 },
+              "wazuh" : {
+                "agent" : { "id" : "001", "name" : "agent-alpha" },
+                "cluster" : { "name" : "wazuh-cluster" }
+              }
+            }
+        """.trimIndent()
+        indexDoc(sourceIndex, "src-1", testDoc)
 
         val docQuery = DocLevelQuery(query = "rule.level:>=10", name = "high_severity", fields = listOf())
         val docLevelInput = DocLevelMonitorInput("description", listOf(sourceIndex), listOf(docQuery))
-        val trigger = randomDocumentLevelTrigger(condition = ALWAYS_RUN)
+        val triggerName = "block-agent"
+        val trigger = randomDocumentLevelTrigger(name = triggerName, condition = ALWAYS_RUN)
 
         val arMonitor = Monitor(
             name = "ar-output-it-${randomAlphaOfLength(5)}",
@@ -67,17 +87,28 @@ class ActiveResponseMonitorOutputIT : AlertingRestTestCase() {
 
         executeMonitor(monitor.id)
 
-        // AR path skips the synchronous refresh in bulkIndexFindings, so refresh explicitly before asserting.
+        // AR path skips the synchronous refresh in bulkIndexFindings — refresh explicitly to read back.
         refreshIndex(arWriteAlias)
-        val arHits = searchHitsByMonitorId(arWriteAlias, monitor.id)
-        assertEquals("AR doc was not written to $arWriteAlias", 1, arHits)
+        val arHits = searchHits(arWriteAlias, """{ "query" : { "match_all" : {} } }""")
+        assertEquals("Expected exactly one AR doc in $arWriteAlias", 1, arHits.size)
 
-        // Findings history index must be empty for this monitor.
-        val findingsHits = searchHitsByMonitorId(AlertIndices.ALL_FINDING_INDEX_PATTERN, monitor.id)
+        @Suppress("UNCHECKED_CAST")
+        val doc = arHits.first()
+        assertNotNull("Missing @timestamp", doc["@timestamp"])
+        val event = doc["event"] as Map<String, Any>
+        assertEquals("src-1", event["doc_id"])
+        assertEquals(sourceIndex, event["index"])
+        val wazuh = doc["wazuh"] as Map<String, Any>
+        val activeResponse = wazuh["active_response"] as Map<String, Any>
+        assertEquals(triggerName, activeResponse["name"])
+        val agent = wazuh["agent"] as Map<String, Any>
+        assertEquals("001", agent["id"])
+        assertEquals("agent-alpha", agent["name"])
+
+        // Standard findings/alerts indices must remain untouched for this monitor.
+        val findingsHits = countHitsByMonitorId(AlertIndices.ALL_FINDING_INDEX_PATTERN, monitor.id)
         assertEquals("AR monitor must not write to the findings history index", 0, findingsHits)
-
-        // Alert index must contain no doc-level alerts for this monitor.
-        val alertHits = searchHitsByMonitorId(AlertIndices.ALERT_INDEX, monitor.id)
+        val alertHits = countHitsByMonitorId(AlertIndices.ALERT_INDEX, monitor.id)
         assertEquals("AR monitor must not produce alerts", 0, alertHits)
     }
 
@@ -115,7 +146,19 @@ class ActiveResponseMonitorOutputIT : AlertingRestTestCase() {
         }
     }
 
-    private fun searchHitsByMonitorId(index: String, monitorId: String): Int {
+    @Suppress("UNCHECKED_CAST")
+    private fun searchHits(index: String, body: String): List<Map<String, Any>> {
+        val response = adminClient().makeRequest(
+            "GET", "/$index/_search?ignore_unavailable=true",
+            StringEntity(body, ContentType.APPLICATION_JSON)
+        )
+        assertEquals("Search failed on $index", RestStatus.OK, response.restStatus())
+        val parser = createParser(JsonXContent.jsonXContent, response.entity.content)
+        val searchResponse = SearchResponse.fromXContent(parser)
+        return searchResponse.hits.hits.map { it.sourceAsMap as Map<String, Any> }
+    }
+
+    private fun countHitsByMonitorId(index: String, monitorId: String): Int {
         val body = """
             { "query" : { "term" : { "monitor_id" : "$monitorId" } } }
         """.trimIndent()
@@ -125,7 +168,6 @@ class ActiveResponseMonitorOutputIT : AlertingRestTestCase() {
         )
         assertEquals("Search failed on $index", RestStatus.OK, response.restStatus())
         val parser = createParser(JsonXContent.jsonXContent, response.entity.content)
-        val searchResponse = SearchResponse.fromXContent(parser)
-        return searchResponse.hits.hits.size
+        return SearchResponse.fromXContent(parser).hits.hits.size
     }
 }

--- a/alerting/src/test/kotlin/org/opensearch/alerting/ActiveResponseMonitorOutputIT.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/ActiveResponseMonitorOutputIT.kt
@@ -105,11 +105,13 @@ class ActiveResponseMonitorOutputIT : AlertingRestTestCase() {
         assertEquals("001", agent["id"])
         assertEquals("agent-alpha", agent["name"])
 
-        // Standard findings/alerts indices must remain untouched for this monitor.
+        // Findings history must remain empty — AR persists only the Wazuh doc, not Findings.
         val findingsHits = countHitsByMonitorId(AlertIndices.ALL_FINDING_INDEX_PATTERN, monitor.id)
         assertEquals("AR monitor must not write to the findings history index", 0, findingsHits)
+
+        // Alerts ARE created so AR firings surface via GET /_plugins/_alerting/monitors/alerts.
         val alertHits = countHitsByMonitorId(AlertIndices.ALERT_INDEX, monitor.id)
-        assertEquals("AR monitor must not produce alerts", 0, alertHits)
+        assertEquals("AR monitor should produce one alert per triggered doc", 1, alertHits)
     }
 
     fun `test active response monitor rejects shouldCreateSingleAlertForFindings`() {


### PR DESCRIPTION
### Description
This PR fixes an issue where Active Responses where written to findings indices (which were their source at the same time). This caused an infinite loop. The Active Responses are now written to their own data-stream.

### Related Issues
Resolves #61 