### PR TITLE
Add limits to monitors

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -27,9 +27,11 @@ class AlertingSettings {
         const val DEFAULT_FAN_OUT_NODES = 1000
         const val DEFAULT_MAX_TRIGGERS_PER_MONITOR = 10
 
+        const val DEFAULT_MAX_MONITORS = 10
+
         val ALERTING_MAX_MONITORS = Setting.intSetting(
             "plugins.alerting.monitor.max_monitors",
-            LegacyOpenDistroAlertingSettings.ALERTING_MAX_MONITORS,
+            DEFAULT_MAX_MONITORS,
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportIndexMonitorAction.kt
@@ -188,6 +188,7 @@ class TransportIndexMonitorAction @Inject constructor(
         request: IndexMonitorRequest,
         user: User?,
     ) {
+        val isInternal = request.internalCaller
         val indices = mutableListOf<String>()
         // todo: for doc level alerting: check if index is present before monitor is created.
         val searchInputs = request.monitor.inputs.filter {
@@ -217,7 +218,7 @@ class TransportIndexMonitorAction @Inject constructor(
                 override fun onResponse(searchResponse: SearchResponse) {
                     // User has read access to configured indices in the monitor, now create monitor with out user context.
                     client.threadPool().threadContext.stashContext().use {
-                        IndexMonitorHandler(client, actionListener, request, user).resolveUserAndStart()
+                        IndexMonitorHandler(client, actionListener, request, user, isInternal).resolveUserAndStart()
                     }
                 }
 
@@ -254,8 +255,9 @@ class TransportIndexMonitorAction @Inject constructor(
         request: IndexMonitorRequest,
         user: User?,
     ) {
+        val isInternal = request.internalCaller
         client.threadPool().threadContext.stashContext().use {
-            IndexMonitorHandler(client, actionListener, request, user).resolveUserAndStartForAD()
+            IndexMonitorHandler(client, actionListener, request, user, isInternal).resolveUserAndStartForAD()
         }
     }
 
@@ -264,6 +266,7 @@ class TransportIndexMonitorAction @Inject constructor(
         private val actionListener: ActionListener<IndexMonitorResponse>,
         private val request: IndexMonitorRequest,
         private val user: User?,
+        private val internalCaller: Boolean = false,
     ) {
 
         fun resolveUserAndStart() {
@@ -391,8 +394,16 @@ class TransportIndexMonitorAction @Inject constructor(
                 scope.launch {
                     updateMonitor()
                 }
+            } else if (internalCaller) {
+                // Internal callers (e.g. Content Manager via SAP) bypass the max monitors limit
+                // so that standard detectors can always create their monitors.
+                scope.launch {
+                    indexMonitor()
+                }
             } else {
-                val query = QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("${Monitor.MONITOR_TYPE}.type", Monitor.MONITOR_TYPE))
+                val query = QueryBuilders.boolQuery()
+                    .filter(QueryBuilders.termQuery("${Monitor.MONITOR_TYPE}.type", Monitor.MONITOR_TYPE))
+                    .mustNot(QueryBuilders.termQuery("${Monitor.MONITOR_TYPE}.${Monitor.OWNER_FIELD}", "security_analytics"))
                 val searchSource = SearchSourceBuilder().query(query).timeout(requestTimeout)
                 val searchRequest = SearchRequest(SCHEDULED_JOBS_INDEX).source(searchSource)
 

--- a/alerting/src/test/kotlin/org/opensearch/alerting/settings/AlertingSettingsTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/settings/AlertingSettingsTests.kt
@@ -161,7 +161,6 @@ class AlertingSettingsTests : OpenSearchTestCase() {
 
         assertSettingDeprecationsAndWarnings(
             arrayOf(
-                LegacyOpenDistroAlertingSettings.ALERTING_MAX_MONITORS,
                 LegacyOpenDistroAlertingSettings.INPUT_TIMEOUT,
                 LegacyOpenDistroAlertingSettings.INDEX_TIMEOUT,
                 LegacyOpenDistroAlertingSettings.BULK_TIMEOUT,

--- a/alerting/src/test/kotlin/org/opensearch/alerting/settings/AlertingSettingsTests.kt
+++ b/alerting/src/test/kotlin/org/opensearch/alerting/settings/AlertingSettingsTests.kt
@@ -136,7 +136,7 @@ class AlertingSettingsTests : OpenSearchTestCase() {
             .put("opendistro.scheduled_jobs.sweeper.period", TimeValue.timeValueMinutes(5))
             .put("opendistro.scheduled_jobs.sweeper.page_size", 100).build()
 
-        assertEquals(AlertingSettings.ALERTING_MAX_MONITORS.get(settings), 1000)
+        assertEquals(AlertingSettings.ALERTING_MAX_MONITORS.get(settings), 10)
         assertEquals(AlertingSettings.INPUT_TIMEOUT.get(settings), TimeValue.timeValueSeconds(30))
         assertEquals(AlertingSettings.INDEX_TIMEOUT.get(settings), TimeValue.timeValueSeconds(60))
         assertEquals(AlertingSettings.BULK_TIMEOUT.get(settings), TimeValue.timeValueSeconds(120))

--- a/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/SampleRemoteMonitorRestHandler.java
+++ b/sample-remote-monitor-plugin/src/main/java/org/opensearch/alerting/SampleRemoteMonitorRestHandler.java
@@ -105,7 +105,8 @@ public class SampleRemoteMonitorRestHandler extends BaseRestHandler {
                 WriteRequest.RefreshPolicy.IMMEDIATE,
                 RestRequest.Method.POST,
                 monitor1,
-                null
+                null,
+                false
         );
 
         if (runMonitorParam.equals("single")) {
@@ -167,7 +168,8 @@ public class SampleRemoteMonitorRestHandler extends BaseRestHandler {
                     WriteRequest.RefreshPolicy.IMMEDIATE,
                     RestRequest.Method.POST,
                     monitor2,
-                    null
+                    null,
+                    false
             );
 
             return restChannel -> {
@@ -252,7 +254,8 @@ public class SampleRemoteMonitorRestHandler extends BaseRestHandler {
                     WriteRequest.RefreshPolicy.IMMEDIATE,
                     RestRequest.Method.POST,
                     remoteDocLevelMonitor,
-                    null
+                    null,
+                    false
             );
             return restChannel -> {
                 client.doExecute(


### PR DESCRIPTION
### Description
This PR modifies the alerting plugin to limit the number of custom created monitors to 10

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1589

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).