### PR TITLE
Add SLF4J provider to alerting plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fix publish-findings forEach try/catch dropping rest of batch on first error [(#49)](https://github.com/wazuh/wazuh-indexer-alerting/pull/49)
+- Fix SLF4J startup warning by adding Log4j2 provider [(#74)](https://github.com/wazuh/wazuh-indexer-alerting/pull/74)
 
   
 

--- a/alerting/build.gradle
+++ b/alerting/build.gradle
@@ -172,6 +172,8 @@ dependencies {
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
     api "org.opensearch.plugin:percolator-client:${opensearch_version}"
 
+    runtimeOnly "org.apache.logging.log4j:log4j-slf4j2-impl:${versions.log4j}"
+
     // OpenSearch Nanny state
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"


### PR DESCRIPTION
### Description
The alerting plugin declared `slf4j-api` 2.x but had no SLF4J provider, causing a "No SLF4J providers found" warning at startup. Adds `log4j-slf4j2-impl` as `runtimeOnly` to bridge SLF4J to Log4j2.

### Issues Resolved
Resolves wazuh/wazuh-indexer#1577
