### PR TITLE
Disable non needed refresh

### DIFF
--- a/alerting/src/main/kotlin/org/opensearch/alerting/WorkflowService.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/WorkflowService.kt
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchException
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsResponse
+import org.opensearch.action.admin.indices.refresh.RefreshRequest
 import org.opensearch.action.search.SearchRequest
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.alerting.opensearchapi.suspendUntil
@@ -51,6 +52,11 @@ class WorkflowService(
                 exists(IndicesExistsRequest(dataSources.findingsIndex).local(true), it)
             }
             if (existsResponse.isExists == false) return Pair(emptyMap(), listOf())
+            // Refresh the findings index so the upstream delegates findings from this same workflow
+            // run are visible to the search below.
+            client.admin().indices().suspendUntil {
+                refresh(RefreshRequest(dataSources.findingsIndex), it)
+            }
             // Search findings index to match id of monitors and workflow execution id
             val bqb = QueryBuilders.boolQuery()
                 .filter(

--- a/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/transport/TransportDocLevelMonitorFanOutAction.kt
@@ -12,8 +12,6 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchSecurityException
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.DocWriteRequest
-import org.opensearch.action.admin.indices.refresh.RefreshAction
-import org.opensearch.action.admin.indices.refresh.RefreshRequest
 import org.opensearch.action.bulk.BackoffPolicy
 import org.opensearch.action.bulk.BulkRequest
 import org.opensearch.action.bulk.BulkResponse
@@ -658,7 +656,6 @@ class TransportDocLevelMonitorFanOutAction
                 log.debug("[${bulkResponse.items.size}] All findings successfully indexed.")
             }
         }
-        client.execute(RefreshAction.INSTANCE, RefreshRequest(monitor.dataSources.findingsIndex))
     }
 
     private fun publishFinding(


### PR DESCRIPTION
### Description
Removes the forced index refresh that ran after every finding's bulk batch, findings now rely on the standard auto-refresh interval 
### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1683

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).