### PR TITLE
Add minimum and maximum limits for monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Repo initialization [(#2)](https://github.com/wazuh/wazuh-indexer-alerting/pull/2)
 - Add Support Revert Bump Functionality [(#23)](https://github.com/wazuh/wazuh-indexer-alerting/pull/23)
 - Implement dedicated monitor for Active Response [(#66)](https://github.com/wazuh/wazuh-indexer-alerting/pull/66)
+- Add minimum and maximum limits for monitors [(#95)](https://github.com/wazuh/wazuh-indexer-alerting/pull/95)
 
 ### Dependencies
 

--- a/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
+++ b/alerting/src/main/kotlin/org/opensearch/alerting/settings/AlertingSettings.kt
@@ -27,11 +27,15 @@ class AlertingSettings {
         const val DEFAULT_FAN_OUT_NODES = 1000
         const val DEFAULT_MAX_TRIGGERS_PER_MONITOR = 10
 
-        const val DEFAULT_MAX_MONITORS = 10
+        private const val MAXIMUM_MAX_MONITORS = 10
+        const val DEFAULT_MAX_MONITORS = MAXIMUM_MAX_MONITORS
+        private const val MINIMUM_MAX_MONITORS = 0
 
         val ALERTING_MAX_MONITORS = Setting.intSetting(
             "plugins.alerting.monitor.max_monitors",
             DEFAULT_MAX_MONITORS,
+            MINIMUM_MAX_MONITORS,
+            MAXIMUM_MAX_MONITORS,
             Setting.Property.NodeScope, Setting.Property.Dynamic
         )
 


### PR DESCRIPTION
### Description
This PR implements minimum and maximum limits for the number of monitors that can be created.

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1276

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).